### PR TITLE
Gouraud shading implementation

### DIFF
--- a/src/shader_fragment.glsl
+++ b/src/shader_fragment.glsl
@@ -36,7 +36,8 @@ uniform sampler2D TextureImage2;
 uniform sampler2D TextureImage3;
 
 // Valores de entrada ("in") de um Fragment Shader vêm do Vertex Shader
-in vec3 gouraud_color;
+in vec3 gouraud_shading_diffuse_ambient;
+in vec3 gouraud_shading_specular;
 
 // O valor de saída ("out") de um Fragment Shader é a cor final do fragmento.
 out vec3 color;
@@ -144,7 +145,7 @@ void main()
         // Blinn-Phong Shading
         // vec4 h = (v + l) / length(v + l);
         // color = Kd0 * (lambert + 0.01) + vec3(0.2, 0.3, 1) * vec3(1, 1, 1) + vec3(1, 1, 1) * pow(dot(n, h), 80);
-        color = gouraud_color;
+        color = (Kd0 * gouraud_shading_diffuse_ambient) + gouraud_shading_specular;
     } else if (object_id == PLANE) {
         color = Kd3 * (lambert + 0.01);
     } else {

--- a/src/shader_fragment.glsl
+++ b/src/shader_fragment.glsl
@@ -35,6 +35,9 @@ uniform sampler2D TextureImage1;
 uniform sampler2D TextureImage2;
 uniform sampler2D TextureImage3;
 
+// Valores de entrada ("in") de um Fragment Shader vêm do Vertex Shader
+in vec3 gouraud_color;
+
 // O valor de saída ("out") de um Fragment Shader é a cor final do fragmento.
 out vec3 color;
 
@@ -139,9 +142,9 @@ void main()
         color = Kd2 * (lambert + 0.01);
     } else if (object_id == COW) {
         // Blinn-Phong Shading
-        vec4 h = (v + l) / length(v + l);
-
-        color = Kd0 * (lambert + 0.01) + vec3(0.2, 0.3, 1) * vec3(1, 1, 1) + vec3(1, 1, 1) * pow(dot(n, h), 80);
+        // vec4 h = (v + l) / length(v + l);
+        // color = Kd0 * (lambert + 0.01) + vec3(0.2, 0.3, 1) * vec3(1, 1, 1) + vec3(1, 1, 1) * pow(dot(n, h), 80);
+        color = gouraud_color;
     } else if (object_id == PLANE) {
         color = Kd3 * (lambert + 0.01);
     } else {

--- a/src/shader_vertex.glsl
+++ b/src/shader_vertex.glsl
@@ -107,8 +107,9 @@ void main()
         float lambert = max(0,dot(n,l));
 
         vec4 h = (v + l) / length(v + l);
+        float dot_positive = max(0, dot(n, h));
         gouraud_shading_diffuse_ambient = lambert + vec3(0.2, 0.3, 1) * vec3(1, 1, 1);
-        gouraud_shading_specular        = vec3(1, 1, 1) * pow(dot(n, h), 80);
+        gouraud_shading_specular        = vec3(1, 1, 1) * pow(dot_positive, 80);
     }
 
     // Coordenadas de textura obtidas do arquivo OBJ (se existirem!)

--- a/src/shader_vertex.glsl
+++ b/src/shader_vertex.glsl
@@ -28,10 +28,8 @@ uniform mat4 view;
 uniform mat4 projection;
 
 // Valores de saída ("out") de um Vertex Shader são repassados para o Fragment Shader
-out vec3 gouraud_color;
-
-// O valor de saída ("out") de um Fragment Shader é a cor final do fragmento.
-out vec3 color;
+out vec3 gouraud_shading_diffuse_ambient;
+out vec3 gouraud_shading_specular;
 
 // Atributos de v�rtice que ser�o gerados como sa�da ("out") pelo Vertex Shader.
 // ** Estes ser�o interpolados pelo rasterizador! ** gerando, assim, valores
@@ -94,9 +92,10 @@ void main()
         float U = (position_model.x - minx)/(maxx - minx);
         float V = (position_model.y - miny)/(maxy - miny);
 
-        vec3 Kd0 = texture(TextureImage0, vec2(U,V)).rgb;
-        vec3 Kd1 = texture(TextureImage1, vec2(U,V)).rgb;
-        vec3 Kd2 = texture(TextureImage2, vec2(U,V)).rgb;
+        // Texture mapping will be applied per-pixel in the Fragment Shader
+        // vec3 Kd0 = texture(TextureImage0, vec2(U,V)).rgb;
+        // vec3 Kd1 = texture(TextureImage1, vec2(U,V)).rgb;
+        // vec3 Kd2 = texture(TextureImage2, vec2(U,V)).rgb;
 
         vec4 origin = vec4(0.0, 0.0, 0.0, 1.0);
         vec4 camera_position = inverse(view) * origin;
@@ -108,7 +107,8 @@ void main()
         float lambert = max(0,dot(n,l));
 
         vec4 h = (v + l) / length(v + l);
-        gouraud_color = Kd0 * (lambert + 0.01) + vec3(0.2, 0.3, 1) * vec3(1, 1, 1) + vec3(1, 1, 1) * pow(dot(n, h), 80);
+        gouraud_shading_diffuse_ambient = lambert + vec3(0.2, 0.3, 1) * vec3(1, 1, 1);
+        gouraud_shading_specular        = vec3(1, 1, 1) * pow(dot(n, h), 80);
     }
 
     // Coordenadas de textura obtidas do arquivo OBJ (se existirem!)

--- a/src/shader_vertex.glsl
+++ b/src/shader_vertex.glsl
@@ -27,6 +27,9 @@ uniform mat4 model;
 uniform mat4 view;
 uniform mat4 projection;
 
+// Valores de saída ("out") de um Vertex Shader são repassados para o Fragment Shader
+out vec3 gouraud_color;
+
 // O valor de saída ("out") de um Fragment Shader é a cor final do fragmento.
 out vec3 color;
 
@@ -105,7 +108,7 @@ void main()
         float lambert = max(0,dot(n,l));
 
         vec4 h = (v + l) / length(v + l);
-        color = Kd0 * (lambert + 0.01) + vec3(0.2, 0.3, 1) * vec3(1, 1, 1) + vec3(1, 1, 1) * pow(dot(n, h), 80);
+        gouraud_color = Kd0 * (lambert + 0.01) + vec3(0.2, 0.3, 1) * vec3(1, 1, 1) + vec3(1, 1, 1) * pow(dot(n, h), 80);
     }
 
     // Coordenadas de textura obtidas do arquivo OBJ (se existirem!)


### PR DESCRIPTION
- Fix Gouraud shading: export gouraud_color from vertex shader to fragment shader.
- Improve Gouraud shading: perform texture mapping in the fragment shader.
- Bugfix in Gouraud shading: avoid negative dot product by taking max(0, dot).
